### PR TITLE
Reference other GH Actions by version number instead of commit hash

### DIFF
--- a/.github/workflows/pre_commit.yml
+++ b/.github/workflows/pre_commit.yml
@@ -11,8 +11,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out code
-        uses: actions/checkout@2541b1294d2704b0964813337f33b291d3f8596b
+        uses: actions/checkout@v3
       - name: Pre-commit checks
-        uses: pre-commit/action@9b88afc9cd57fd75b655d5c71bd38146d07135fe
+        uses: pre-commit/action@3.0.0
         with:
           extra_args: --all-files

--- a/.github/workflows/pre_commit.yml
+++ b/.github/workflows/pre_commit.yml
@@ -13,6 +13,6 @@ jobs:
       - name: Check out code
         uses: actions/checkout@v3
       - name: Pre-commit checks
-        uses: pre-commit/action@3.0.0
+        uses: pre-commit/action@v3.0.0
         with:
           extra_args: --all-files

--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -8,9 +8,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out code
-        uses: actions/checkout@2541b1294d2704b0964813337f33b291d3f8596b
+        uses: actions/checkout@v3
       - name: Set up go
-        uses: actions/setup-go@268d8c0ca0432bb2cf416faae41297df9d262d7f
+        uses: actions/setup-go@v3
         with:
           go-version-file: './go.mod'
           cache: true


### PR DESCRIPTION
No Jira ticket, just a small update to how the GH Actions workflows are written, following some of the changes on https://github.com/CMSgov/easi-app/pull/1848. Should also close https://github.com/CMSgov/easi-shared/pull/19 on this repo.